### PR TITLE
fix new URL('.', import.meta.url) produce erroneous path on Windows

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
 import { main } from '../build/index.js';
 
 // Assuming the current file is located at /home/user/project/app.js

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,13 +2,13 @@
 import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
-
+import { fileURLToPath } from 'url';
 import { main } from '../build/index.js';
 
 // Assuming the current file is located at /home/user/project/app.js
-const dirname = path.join(new URL('.', import.meta.url).pathname);
+const dirname = fileURLToPath(new URL('.', import.meta.url));
 const packageJson = JSON.parse(
-  fs.readFileSync(path.join(dirname, '../package.json'), 'utf8'),
+  fs.readFileSync(path.join(dirname, '..', 'package.json'), 'utf8'),
 );
 const program = new Command();
 const runTypes = ['test', 'review', 'translate', 'create', 'modify'];


### PR DESCRIPTION
The path that is created in Windows is incorrect.
`\C:\Users\PC\AppData\Roaming\npm\node_modules\huskygpt\package.json`

The correct output should be:
`C:\Users\PC\AppData\Roaming\npm\node_modules\huskygpt\package.json`

**Additional Information**
```
PS C:\WINDOWS\system32> huskygpt -h
node:fs:590
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open '\C:\Users\PC\AppData\Roaming\npm\node_modules\huskygpt\package.json'
    at Object.openSync (node:fs:590:3)
    at Object.readFileSync (node:fs:458:35)
    at file:///C:/Users/PC/AppData/Roaming/npm/node_modules/huskygpt/bin/cli.js:11:6
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:526:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12) {
  errno: -4058,
  syscall: 'open',
  code: 'ENOENT',
  path: '\\C:\\Users\\PC\\AppData\\Roaming\\npm\\node_modules\\huskygpt\\package.json'
}
```